### PR TITLE
Rename elseWhen to where

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some proposals would bring more powerful conditional expressions to JavaScript l
 
 Here's an example that handles the status of an API call using the `Match` function:
 
-```ts
+```js
 function Example() {
   const { status, error, data } = useQuery("repoData", () =>
     fetch("https://api.github.com/repos/richeyryan/quando").then(res =>
@@ -73,8 +73,8 @@ The equivalent of an if statement.
 import { When } from "quando";
 
 When(status === "loading", <Loading />)
-  .elseWhen(status === "error", <Error message="Failed to load user" />)
-  .elseWhen(status === "success", <User user={user} />)
+  .where(status === "error", <Error message="Failed to load user" />)
+  .where(status === "success", <User user={user} />)
   .end();
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ class WhenCondition<R> {
   constructor(controller: Controller<R>) {
     this.controller = controller;
   }
-  elseWhen(condition: Boolean, result: QuandoParam<R>) {
+  where(condition: Boolean, result: QuandoParam<R>) {
     this.controller.updateResult(condition, result);
     return this;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,15 +14,15 @@ describe("Quando", () => {
       expect(When<number>(false, 1).end(0)).toBe(0);
       expect(When<number>(false, 1).end(() => 0)).toBe(0);
     });
-    it("returns the elseWhen conditon when the initial condition is false", () => {
+    it("returns the where conditon when the initial condition is false", () => {
       expect(
         When<number>(false, 1)
-          .elseWhen(true, 99)
+          .where(true, 99)
           .end(0),
       ).toBe(99);
       expect(
         When<number>(false, 1)
-          .elseWhen(true, () => 99)
+          .where(true, () => 99)
           .end(0),
       ).toBe(99);
     });
@@ -30,12 +30,12 @@ describe("Quando", () => {
     it("returns the default when the initial condition is false and there is an else condition but it is also false", () => {
       expect(
         When<number>(false, 1)
-          .elseWhen(false, 99)
+          .where(false, 99)
           .end(0),
       ).toBe(0);
       expect(
         When<number>(false, 1)
-          .elseWhen(false, 99)
+          .where(false, 99)
           .end(() => 0),
       ).toBe(0);
     });
@@ -43,7 +43,7 @@ describe("Quando", () => {
     it("returns undefined when the initial condition is false and there is an else condition but it is also false and the default is not supplied", () => {
       expect(
         When<number>(false, 1)
-          .elseWhen(false, 99)
+          .where(false, 99)
           .end(),
       ).toBeUndefined();
     });


### PR DESCRIPTION
- It's consistent with `Match`
- It's shorter and only one word